### PR TITLE
Add templates and guidance for contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+To propose a new topic, please write up a short summary and motivation for it as a starting point for the discussion.
+
+### Summary
+
+_What is needed. A one paragraph explanation of what this is about._
+
+> A WebExtension API to provide interfaces to raw UDP sockets, TCP Client sockets and TCP Server sockets.
+
+### Motivation
+
+_Why is it needed? What does it unlock?_
+
+> To allow us to build out p2p protocol handlers without having to work around the assumptions of HTTP or centralized authorities.

--- a/README.md
+++ b/README.md
@@ -3,22 +3,36 @@
 _Let's unlock the peer-to-peer web_ ⚡🌐🔑
 
 > ...a comprehensive, prioritized list that we can point browser people too. Ideally with a brief description which features each of the items unlocks. There are things which are absolute deal-breakers (e.g. proper protocol handlers), and things which are important but not essential. The list should convey this importance and priorities.
-
 > @lgierth
 
 ## Usage
 
-- `make dev` - Dev mode. See the site (with live reloading) at http://localhost:1313
-- `make` - Build the production ready site to `./public`
+- `make dev` - Dev mode. See the site with live reloading at http://localhost:1313
+- `make` - Build the static site to `./public`
 - `make deploy` - Add `./public` to [IPFS]
 - `make help` - For more info
 
-- Built with [hugo]
-- Styled with [tachyons] & [ipfs-css]
+Built with [hugo], styled with [tachyons] & [ipfs-css]
 
-## Adding content
+## Contributing
 
-The site is built from `data/topics.json`. Add your feature or browser specific details on an existing feature there and submit a PR.
+This site documents the browser apis, features and bug fixes needed to improve the user-experience of the distributed web.
+
+**Come join us** in the <a href="https://www.irccloud.com/invite?channel=%23ipfs-in-web-browsers&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1"> #ipfs-in-web-browsers channel on irc.freenode.net</a> and feel free to ask questions!
+
+**To suggest a new topic** create a new issue for it on the GitHub repo https://github.com/ipfs-shipyard/arewedistributedyet/issue where we can figure out the details.
+
+Each topic should define what is needed, and what feature it unlocks. There is an issue template to guide the process. We'll discuss the issue and look for consensus on the ideal specification, and encourage p2p protocol developers and browser developers to help refine each issue.
+
+**To submit a proposal** create a new markdown document in the `./content` directory by running
+
+```sh
+hugo new <your-hyphenated-lowercase-topic-title-here.md>
+```
+
+That will create the proposal structure for you, with the filename you provided in the content dir. Once your happy with it, submit it as PR.
+
+**To update the homepage** update `data/topics.json` with the new feature or browser specific details and submit a PR.
 
 Data for a topic looks like this
 
@@ -56,10 +70,12 @@ Where
 - `level: 1` means the browser is positive, but there are caveats or unknowns.
 - `level: 2` means the idea is shipped or they are publicly committed to shipping it.
 
+Once there is a published proposal document for a topic, you can add a link to it by adding a `doc` property with the proposal filename (without it's file extension) as the value, in the relevant topic object in `data/topics.json`.
+
 ## Inspiration
 
-- https://jakearchibald.github.io/isserviceworkerready/
-- http://www.areweplayingyet.org/
+- http://www.areweplayingyet.org
+- https://jakearchibald.github.io/isserviceworkerready
 - https://github.com/datprotocol/DEPs
 
 ## License

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,31 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+draft: true
+---
+
+## Summary
+
+_What is needed. A one paragraph explanation of what this is about._
+
+## Motivation
+
+_Why is it needed? What does it unlock?_
+
+_Do any practical workarounds exist? What is the current pattern or hack to achieve a similar outcome._
+
+## Usage Documentation
+
+_Document new features as if they are already implemented. Provide code examples using the new api. This section should introduce new concepts and terms, describe use cases or situations._
+
+## Status
+
+_Summary of the current spec and per browser implementation status. Add links to latest discussions._
+
+- **W3C**: ?
+- **Brave**: ?
+- **Beaker**: ?
+- **Chromium**: ?
+- **Edge**: ?
+- **Firefox**: ?
+- **Safari**: ?


### PR DESCRIPTION
- Adds a github issue template to streamline the process of adding new topics.
- Adds a hugo archetype (a markdown template) for help structure new proposal documents.
- Updates the readme with notes on how to contribute, and an irc link.